### PR TITLE
Fix Firebase credentials path

### DIFF
--- a/daily_portfolio_logger.py
+++ b/daily_portfolio_logger.py
@@ -26,7 +26,7 @@ except ImportError:
 
 # --- CONFIGURATION ---
 SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
-SERVICE_ACCOUNT_KEY_PATH = SERVICE_ACCOUNT_KEY_PATH = "firebase-service-account-key.json"
+SERVICE_ACCOUNT_KEY_PATH = os.path.join(SCRIPT_DIR, "firebase-service-account-key.json")
 # USER_ID is now imported or defined above
 
 # --- Firebase Initialization for this script ---

--- a/firebase_utils.py
+++ b/firebase_utils.py
@@ -38,7 +38,7 @@ def initialize_firebase_admin():
             return None 
         except Exception as e1: 
             st.error(f"Failed to initialize Firebase from secrets: {e1}. Trying local file...")
-            local_cred_path = "dontknwo/firebase-service-account-key.json" 
+            local_cred_path = os.path.join(os.path.dirname(__file__), "firebase-service-account-key.json")
             try:
                 if not os.path.exists(local_cred_path):
                     st.error(f"Local Firebase credentials file not found at: {local_cred_path}. Firebase NOT initialized.")


### PR DESCRIPTION
## Summary
- fix fallback credentials path in `firebase_utils`
- correct service account path in `daily_portfolio_logger`

## Testing
- `python -m py_compile firebase_utils.py daily_portfolio_logger.py`

------
https://chatgpt.com/codex/tasks/task_e_6847d758fb488323b714a43ce083f230