### PR TITLE
Add tests for parse_date_from_string

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -1,0 +1,23 @@
+name: Python package tests
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install pytest
+      - name: Run tests
+        run: pytest -q

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,22 @@
+import datetime
+import os
+import sys
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from utils import parse_date_from_string
+
+
+def test_parse_iso_format():
+    assert parse_date_from_string('2024-01-15') == datetime.date(2024, 1, 15)
+    assert parse_date_from_string('15-Jan-2024') == datetime.date(2024, 1, 15)
+
+
+def test_parse_datetime_date_repr():
+    assert parse_date_from_string('datetime.date(2024, 1, 15)') == datetime.date(2024, 1, 15)
+
+
+def test_parse_invalid_inputs():
+    for bad in ['not a date', '', None, 123]:
+        assert parse_date_from_string(bad) is None

--- a/utils.py
+++ b/utils.py
@@ -42,9 +42,11 @@ def parse_date_from_string(date_str):
 
     try:
         dt_obj = pd.to_datetime(date_str, errors='raise')
+        if pd.isna(dt_obj):
+            return None
         return dt_obj.date()
     except (ValueError, TypeError):
-        pass 
+        pass
 
     match_obj_repr = re.match(r"datetime.date\((\d{4}),\s*(\d{1,2}),\s*(\d{1,2})\)", date_str)
     if match_obj_repr:


### PR DESCRIPTION
## Summary
- add pytest workflow
- test utils.parse_date_from_string handling of valid and invalid dates
- fix utils.parse_date_from_string to return None for NaT

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847da0dc0c083238827f90ce2ab7ab8